### PR TITLE
Prepare for Makie 0.22 / GeometryBasics 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,12 @@
 name = "Packing"
 uuid = "19eb6ba3-879d-56ad-ad62-d5c202156566"
-version = "0.5"
+version = "0.5.1"
 
 [deps]
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 
 [compat]
-GeometryBasics = "0.4.1"
+GeometryBasics = "0.4.1, 0.5"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
I'm assuming this only uses Point, Vec, Rect2 which didn't change. If anything else is used we may need a breaking version